### PR TITLE
mintheme: Add tmux compatibility for setTheme

### DIFF
--- a/mintheme
+++ b/mintheme
@@ -221,8 +221,7 @@ settheme() {
 	then # double all Escape control characters, wrap with Ptmux escape sequence
 	    echo $theme | sed \
 	       -e 's///g' \
-	       -e 's/^/Ptmux;/' \
-	       -e 's/$/\\/'
+	       -e 's/^/Ptmux;/'
 	else
 	    echo $theme
 	fi

--- a/mintheme
+++ b/mintheme
@@ -194,7 +194,7 @@ showthemes() {
 }
 
 settheme() {
-	sed \
+	theme=$(sed \
 	    -e 's/^\(ForegroundColour\)[ 	]*=/10;/' \
 	    -e 's/^\(BackgroundColour\)[ 	]*=/11;/' \
 	    -e 's/^\(CursorColour\)[ 	]*=/12;/' \
@@ -216,7 +216,16 @@ settheme() {
 	    -e 's/^\(BoldWhite\)[ 	]*=/4;15;/' \
 	    -e 't ok' -e d -e ': ok' -e 's/[ 	]//g' \
 	    -e "s/^/]/" -e "s/$//" "$1" |
-	tr -d '\012'
+	tr -d '\012')
+	if [ -n "$TMUX" ]
+	then # double all Escape control characters, wrap with Ptmux escape sequence
+	    echo $theme | sed \
+	       -e 's///g' \
+	       -e 's/^/Ptmux;/' \
+	       -e 's/$/\\/'
+	else
+	    echo $theme
+	fi
 	#]4;A;colour	set ANSI colour A=0..15
 	#]10;colour	set foreground colour
 	#]11;colour	set background colour


### PR DESCRIPTION
Discussed in https://github.com/mintty/wsltty/issues/268

I honestly could not find a lot of information on the reliability of this environment variable, but local testing:

|Step|TerminalA $TMUX|TerminalB $TMUX|
|----|---------------------|-------------------|
|Open TerminalA| Not set| N/A|
|Open TerminalB|Not set|Not set|
|in TerminalA, start tmux|/tmp/tmux-1000/default,13334,0| Not Set|
|in TerminalA, in tmux, start bash child session|/tmp/tmux-1000/default,13334,0|Not Set|
|in TerminalA, detach session| Not set | Not set

I'll be running with this locally for some rudimentary day-to-day testing, but so-far-so-good.